### PR TITLE
[M4] Step-1 NO-GO: green-context SM overlap of DSA indexer ∥ main-attention projection loses to serial

### DIFF
--- a/agent-tasks/M4-green-context-indexer-attn-overlap-RESULT.md
+++ b/agent-tasks/M4-green-context-indexer-attn-overlap-RESULT.md
@@ -1,0 +1,123 @@
+# M4 Step-1 result: NO-GO — green-context indexer∥attention overlap does not beat serial
+
+Task: overlap the DSA indexer with the main-attention Q projection via FlashInfer/CUDA
+green-context SM partitioning during long-context prefill
+(`agent-tasks/M4-green-context-indexer-attn-overlap.md`).
+
+**Verdict: the task is dead at Step 1.** At every prefill shape tested (GLM-5.2 TP4 and
+DeepSeek-V3.2 TP8 per-rank shapes, first/middle/last chunks of an 80k prefill, 32k and
+80k single-shot), the best green-context partition is **2–4% slower than serial**, and
+the naive two-stream fork is a wash (1.00× ± 0.03 run-to-run noise). This is not a
+tuning problem; it is arithmetic (see "Why it cannot win" below).
+
+## Step 0 — environment
+
+- 8× NVIDIA B300 SXM6 AC (SM103, **148 SMs**, 275 GB), measurements on GPU 0.
+- torch **2.11.0+cu130** (the torch-2.7/2.8 green-ctx CUDA-graph caveat window does not
+  apply; prefill is eager anyway), driver **610.43.02** (CUDA ≥13.1, so green-ctx
+  workqueue "balanced" scope is available and was tested), flashinfer 0.6.13,
+  sglang @ d7dcdf3efd.
+- Shapes taken from the actual checkpoints' `config.json`
+  (zai-org/GLM-5.2-FP8 & nvidia/GLM-5.2-NVFP4: hidden 6144, 64 heads, qk_head 256,
+  q_lora 2048, indexer 32×128 topk 2048; deepseek-ai/DeepSeek-V3.2: hidden 7168,
+  128 heads, qk_head 192, q_lora 1536, indexer 64×128).
+- On ≥160 GB GPUs sglang defaults `chunked_prefill_size=16384`, so a real 80k prefill
+  is 5 forwards of M=16384 rows against growing KV (N up to 80k). The bench covers that
+  regime plus single-shot 32k/80k.
+
+## What was measured
+
+Region = one DSA layer's overlap window at eager prefill, per rank, with the
+**production kernels**:
+
+- **Side A (main Q-prep)**: `q_b_proj` GEMM (bf16, cuBLAS/TGV path) → q_nope/q_pe split
+  → absorbed `bmm` with `w_kc`.
+- **Side B (whole indexer)**: `wq_b` + `wk_weights_proj` GEMMs,
+  `fused_q_indexer_rope_first_quant`, `fused_k_indexer_norm_rope` + fp8 `act_quant`,
+  chunked `deep_gemm.fp8_mqa_logits`, `sgl_kernel.fast_topk_transform_ragged_fused`.
+
+Arms: serial (today's order) | two-stream on one SM pool | green-context two-way SM
+split (`sglang.srt.multiplex.green_ctx.split_device_green_ctx_by_sm_count`), A-slice
+swept 8→48 SMs, both "wide" (whole indexer on the big slice) and "narrow" (projections
+only, logits/topk after the join on the full device). Timing: CUDA events, median of
+12–20 iters after warmup. Correctness: top-k compared as sorted sets (the fused top-k
+kernel returns the selected set in nondeterministic order run-to-run — pre-existing
+behavior, unrelated to this change), identical across all arms.
+
+## Step-1 table (GLM-5.2 TP4 per-rank shapes; median ms; speedup vs serial)
+
+`deep_gemm` grid sized to the slice in green arms (see hazard note below).
+
+| arm | M=16k, N=16k | M=16k, N=49k | M=16k, N=82k | M=32k, N=32k | M=82k, N=82k (chunked logits) |
+|---|---|---|---|---|---|
+| side A alone (full device) | 0.226 | 0.226 | 0.226 | 0.436 | 1.06 |
+| side B alone (full device) | 1.46 | 4.41 | 7.45 | 4.45 | 22.6 |
+| serial | 1.67 (1.000×) | 4.69 (1.000×) | 7.70 (1.000×) | 4.89 (1.000×) | 23.8 (1.000×) |
+| two-stream (one SM pool) | 0.994× | 1.011× | 0.996× | 0.997× | 0.993× |
+| green a8/b140 | — | — | **0.975×** | — | **0.980×** |
+| green a16/b132 | 0.829×¹ | 0.715×¹ | 0.934× | 0.773×¹ | 0.959× |
+| green a24/b124 | 0.807×¹ | 0.704×¹ | 0.896× | 0.753×¹ | 0.918× |
+| green narrow (best over 8–48) | 0.989× | 0.980× | 0.953× | 0.972× | 0.998× |
+
+¹ columns run before the deep_gemm grid fix also include that penalty; with the fix the
+best wide split is still <1.0 everywhere (0.975–0.990).
+
+- `workqueue_scope="balanced"` (CUDA 13.1): best arm 0.990× — no rescue.
+- **DeepSeek-V3.2 shapes** (M=16k, N=82k): side A 0.154 ms vs side B 12.6 ms (1.2%);
+  best green arm 0.976×, two-stream 1.013× (within noise). Same verdict.
+- Green-ctx split creation: **0.4 ms** one-time — creation cost is a non-issue; it is
+  not why this fails.
+- **Co-residency was real**: profiler trace of green a16/b132 shows side A's kernels
+  overlap side B's kernels for **94.8%** of side A's busy time on disjoint SM slices.
+  The mechanism works; it just costs more than it hides.
+
+## Why it cannot win (the arithmetic that kills it)
+
+1. **The hideable work is tiny.** The only main-side work independent of the indexer
+   output is q_b_proj + q split + absorbed bmm ≈ 0.23 ms at M=16384 — **3.0%** of the
+   8 ms overlap region at N=80k (1.2% for V3.2). The task brief's "~16%" is the
+   indexer's *own* logits+topk share of e2e GPU time; it is on the *indexer* side of
+   the overlap and cannot be recovered by this overlap — it is the thing being
+   overlapped *against*.
+2. **The minimum SM carve-out exceeds the prize.** Both sides are throughput-bound at
+   long-prefill sizes (near-linear SM scaling: side A on 16/148 SMs ran 7.7× slower,
+   matching the trace). Hiding side A saves ≤3% of the region, but the smallest
+   partition the driver allows on B300 is 8 SMs = **5.4%** of the machine, which slows
+   the dominant indexer side by ~4–6% of the region. Loss ≥ gain at every split ratio,
+   in both wide and narrow variants. deep_gemm's logits kernel is ~55–75% of side B and
+   is fp8-tensor-core/SM-bound, so it pays the full proportional tax; the
+   bandwidth-bound top-k does not release enough SM-time to change the balance.
+3. **Two-stream on one SM pool is free and already a wash** (0.99–1.03× = noise),
+   confirming there is no idle-resource window at these kernel sizes for co-scheduling
+   to exploit. (The indexer's internal wq_b ∥ wk_weights_proj two-stream overlap in
+   `_fused_q_prepare_and_store` already runs at eager prefill today — the projections
+   the task proposed to overlap were in fact already partially overlapped.)
+4. **e2e ceiling even for a FREE overlap**: 0.226 ms × 5 chunks × 22 full-indexer
+   layers (GLM-5.2 `index_topk_freq=4`) ≈ 25 ms ≈ **<1% of an 80k prefill**; ≈2–3% if
+   all 78 layers ran full indexers. Measured green-ctx delta is negative, so the real
+   number is a regression.
+
+## Integration hazard found on the way (worth keeping in mind for any green-ctx work)
+
+`deep_gemm.fp8_mqa_logits` sizes its persistent grid from `deep_gemm.get_num_sms()`
+(=148). Launched on a 140-SM green slice, the 148-CTA grid runs as **two waves → ~2×
+slowdown** of the logits kernel (observed: 0.71× overall). Any future green-ctx
+integration must re-plumb per-slice SM counts into deep_gemm (and any other
+persistent-grid kernel) or it will silently halve logits throughput.
+
+## What would change the verdict
+
+- Hardware/driver allowing sub-8-SM partitions AND a main-side share above the
+  minimum-slice fraction (not true for any DSA model here: 1.2–4.7%).
+- Overlapping the indexer against a *large* independent consumer (e.g. cross-layer
+  MoE↔indexer overlap) — out of scope for M4 and a different dependency structure.
+
+## Artifacts
+
+- `bench_step1.py` — the settling experiment (arms: serial / two-stream / green wide /
+  green narrow; presets glm52+dsv32; `--deepgemm-slice-sms`, `--workqueue-scope`).
+- `trace_coresidency.py` — co-residency proof (94.8% overlap on green slices).
+- `res_*.json` — raw numbers.
+
+Per the task's Step-1 gate: green-ctx does not beat serial ⇒ **STOP; no implementation,
+no server-level A/B needed** (Steps 2–5 are moot).

--- a/agent-tasks/m4-step1-bench/bench_step1.py
+++ b/agent-tasks/m4-step1-bench/bench_step1.py
@@ -1,0 +1,320 @@
+"""M4 Step-1 settling experiment.
+
+Region under test = one DSA layer's overlap window at eager prefill
+(GLM-5.2 shapes, TP4 per-rank), bs=1:
+
+  side A (main-attention Q prep, per rank):
+      q_b_proj GEMM [M,2048]x[2048,4096] bf16
+      -> split q_nope/q_pe -> absorbed bmm [16,M,192]x[16,192,512] bf16
+  side B (whole indexer):
+      wq_b GEMM [M,2048]x[2048,4096] bf16
+      wk_weights_proj GEMM [M,6144]x[6144,160] bf16
+      fused_q_indexer_rope_first_quant + fused_k_indexer_norm_rope + act_quant
+      deep_gemm.fp8_mqa_logits  [M rows x N kv]  (row-chunked like the server)
+      fast_topk_transform_ragged_fused (topk=2048)
+
+Arms: serial | two_stream (one SM pool) | green_ctx A-slice sweep.
+"""
+
+import argparse
+import json
+
+import deep_gemm
+import torch
+import torch.nn.functional as F
+from sgl_kernel import fast_topk_transform_ragged_fused
+
+from sglang.jit_kernel.dsv4 import fused_q_indexer_rope_first_quant
+from sglang.jit_kernel.dsv32 import fused_k_indexer_norm_rope
+from sglang.srt.layers.attention.dsa.triton_kernel import act_quant
+from sglang.srt.multiplex.green_ctx import split_device_green_ctx_by_sm_count
+
+PRESETS = {
+    # per-rank shapes
+    "glm52": dict(
+        hidden=6144,
+        q_lora=2048,
+        heads_rank=16,
+        qk_head=256,
+        nope=192,
+        kv_lora=512,
+        idx_heads=32,
+    ),  # TP4
+    "dsv32": dict(
+        hidden=7168,
+        q_lora=1536,
+        heads_rank=16,
+        qk_head=192,
+        nope=128,
+        kv_lora=512,
+        idx_heads=64,
+    ),  # TP8
+}
+HIDDEN = 6144
+Q_LORA = 2048
+HEADS_RANK = 16  # 64 heads / TP4
+QK_HEAD = 256  # 192 nope + 64 rope
+NOPE = 192
+KV_LORA = 512
+IDX_HEADS = 32
+IDX_DIM = 128
+IDX_ROPE = 64
+TOPK = 2048
+MAX_POS = 131072
+
+
+def apply_preset(name):
+    g = globals()
+    for k, v in PRESETS[name].items():
+        g[k.upper()] = v
+
+
+class Workload:
+    def __init__(self, m: int, n: int, sub_chunk_rows: int):
+        dev = torch.device("cuda")
+        g = torch.Generator(device=dev).manual_seed(1234)
+
+        def rand(*shape, dtype=torch.bfloat16, scale=1.0):
+            return (
+                torch.randn(*shape, generator=g, device=dev, dtype=torch.float32).to(
+                    dtype
+                )
+                * scale
+            )
+
+        self.m, self.n = m, n
+        self.sub_chunk_rows = sub_chunk_rows if sub_chunk_rows > 0 else m
+        self.q_lora = rand(m, Q_LORA)
+        self.hidden = rand(m, HIDDEN)
+        self.w_qb = rand(HEADS_RANK * QK_HEAD, Q_LORA, scale=0.02)
+        self.w_kc = rand(HEADS_RANK, NOPE, KV_LORA, scale=0.02)
+        self.w_wqb = rand(IDX_HEADS * IDX_DIM, Q_LORA, scale=0.02)
+        self.w_wkw = rand(IDX_DIM + IDX_HEADS, HIDDEN, scale=0.02)
+        self.ln_w = torch.ones(IDX_DIM, device=dev, dtype=torch.float32)
+        self.ln_b = torch.zeros(IDX_DIM, device=dev, dtype=torch.float32)
+
+        inv_freq = 1.0 / (
+            10000 ** (torch.arange(0, IDX_ROPE, 2, dtype=torch.float32) / IDX_ROPE)
+        )
+        freqs = torch.outer(torch.arange(MAX_POS, dtype=torch.float32), inv_freq)
+        self.cos_sin = torch.cat([freqs.cos(), freqs.sin()], dim=-1).to(dev)
+
+        self.positions = torch.arange(n - m, n, device=dev, dtype=torch.int64)
+        self.ks = torch.zeros(m, device=dev, dtype=torch.int32)
+        self.ke = torch.arange(n - m + 1, n + 1, device=dev, dtype=torch.int32)
+        self.lengths = self.ke.clone()
+        self.topk_offset = torch.zeros(m, device=dev, dtype=torch.int32)
+
+        hist = rand(n, IDX_DIM)
+        self.k_fp8_buf, k_scale = act_quant(hist, 128, None)
+        self.k_scale_buf = k_scale.view(torch.float32).squeeze(-1).contiguous()
+
+        self.q_scale_gate = IDX_DIM**-0.5 * IDX_HEADS**-0.5
+        self.topk_out = torch.full((m, TOPK), -1, device=dev, dtype=torch.int32)
+
+    def side_a(self):
+        q = F.linear(self.q_lora, self.w_qb).view(self.m, HEADS_RANK, QK_HEAD)
+        q_nope, q_pe = q.split([NOPE, QK_HEAD - NOPE], dim=-1)
+        q_nope_out = torch.bmm(q_nope.transpose(0, 1), self.w_kc)
+        return q_nope_out, q_pe
+
+    def side_b_proj(self):
+        qi = F.linear(self.q_lora, self.w_wqb).view(self.m, IDX_HEADS, IDX_DIM)
+        kw = F.linear(self.hidden, self.w_wkw)
+        key_raw, weights_raw = kw.split([IDX_DIM, IDX_HEADS], dim=-1)
+        q_fp8, weights = fused_q_indexer_rope_first_quant(
+            qi.contiguous(),
+            weights_raw,
+            self.q_scale_gate,
+            self.cos_sin,
+            self.positions,
+        )
+        key = fused_k_indexer_norm_rope(
+            key_raw.contiguous(),
+            self.ln_w,
+            self.ln_b,
+            1e-6,
+            self.cos_sin,
+            self.positions,
+        )
+        k_fp8, k_scale = act_quant(key, 128, None)
+        self.k_fp8_buf[self.n - self.m :] = k_fp8
+        self.k_scale_buf[self.n - self.m :] = k_scale.view(torch.float32).squeeze(-1)
+        return q_fp8, weights.squeeze(-1)
+
+    def side_b_logits_topk(self, q_fp8, weights):
+        start = 0
+        while start < self.m:
+            end = min(start + self.sub_chunk_rows, self.m)
+            logits = deep_gemm.fp8_mqa_logits(
+                q_fp8[start:end],
+                (self.k_fp8_buf, self.k_scale_buf),
+                weights[start:end],
+                self.ks[start:end],
+                self.ke[start:end],
+                clean_logits=False,
+            )
+            self.topk_out[start:end] = fast_topk_transform_ragged_fused(
+                score=logits,
+                lengths=self.lengths[start:end],
+                topk_indices_offset=self.topk_offset[start:end],
+                topk=TOPK,
+                row_starts=self.ks[start:end],
+            )
+            start = end
+        return self.topk_out
+
+    def side_b(self):
+        q_fp8, weights = self.side_b_proj()
+        return self.side_b_logits_topk(q_fp8, weights)
+
+
+def time_arm(fn, iters, warmup):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    start_ev = torch.cuda.Event(enable_timing=True)
+    end_ev = torch.cuda.Event(enable_timing=True)
+    for _ in range(iters):
+        start_ev.record()
+        fn()
+        end_ev.record()
+        torch.cuda.synchronize()
+        times.append(start_ev.elapsed_time(end_ev))
+    times.sort()
+    return times[len(times) // 2], times[0]
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--m", type=int, required=True)
+    p.add_argument("--n", type=int, required=True)
+    p.add_argument("--sub-chunk-rows", type=int, default=0)
+    p.add_argument("--iters", type=int, default=20)
+    p.add_argument("--warmup", type=int, default=5)
+    p.add_argument("--a-slices", type=int, nargs="*", default=[16, 24, 32, 48])
+    p.add_argument(
+        "--deepgemm-slice-sms",
+        action="store_true",
+        help="configure deep_gemm num_sms to the indexer slice size in green arms",
+    )
+    p.add_argument("--json-out", type=str, default="")
+    p.add_argument("--preset", choices=list(PRESETS), default="glm52")
+    p.add_argument("--workqueue-scope", type=str, default=None)
+    p.add_argument("--decompose", action="store_true")
+    args = p.parse_args()
+    apply_preset(args.preset)
+
+    torch.cuda.set_device(0)
+    total_sms = torch.cuda.get_device_properties(0).multi_processor_count
+    wl = Workload(args.m, args.n, args.sub_chunk_rows)
+    default = torch.cuda.current_stream()
+
+    results = {}
+
+    def record(name, fn, check_against=None):
+        med, best = time_arm(fn, args.iters, args.warmup)
+        ok = ""
+        if check_against is not None:
+            # The fused topk kernel returns the selected set in nondeterministic
+            # order run-to-run (pre-existing behavior); compare as sorted sets.
+            ok = bool(torch.equal(wl.topk_out.sort(dim=1).values, check_against))
+        results[name] = {"median_ms": med, "best_ms": best, "topk_identical": ok}
+        print(f"{name:>28}: median {med:8.3f} ms   best {best:8.3f} ms   {ok}")
+
+    record("side_a_only", wl.side_a)
+    record("side_b_only", wl.side_b)
+    ref_topk = wl.topk_out.sort(dim=1).values.clone()
+
+    if args.decompose:
+        record("side_b_proj_only", wl.side_b_proj)
+        pq, pw = wl.side_b_proj()
+        torch.cuda.synchronize()
+        record("side_b_logits_topk_only", lambda: wl.side_b_logits_topk(pq, pw))
+
+    def serial():
+        wl.side_a()
+        wl.side_b()
+
+    record("serial", serial, ref_topk)
+
+    plain = torch.cuda.Stream()
+
+    def two_stream():
+        plain.wait_stream(default)
+        with torch.cuda.stream(plain):
+            wl.side_a()
+        wl.side_b()
+        default.wait_stream(plain)
+
+    record("two_stream", two_stream, ref_topk)
+
+    import time
+
+    t0 = time.perf_counter()
+    split_device_green_ctx_by_sm_count(0, [8, total_sms - 8])
+    print(f"green ctx split creation: {(time.perf_counter() - t0) * 1e3:.1f} ms")
+
+    for a_sms in args.a_slices:
+        b_sms = total_sms - a_sms
+        (ga, gb), res = split_device_green_ctx_by_sm_count(
+            0, [a_sms, b_sms], workqueue_scope=args.workqueue_scope
+        )
+        granted = [r.sm.smCount for r in res]
+
+        def green():
+            ga.wait_stream(default)
+            gb.wait_stream(default)
+            with torch.cuda.stream(ga):
+                wl.side_a()
+            with torch.cuda.stream(gb):
+                if args.deepgemm_slice_sms:
+                    old = deep_gemm.get_num_sms()
+                    deep_gemm.set_num_sms(granted[1])
+                    wl.side_b()
+                    deep_gemm.set_num_sms(old)
+                else:
+                    wl.side_b()
+            default.wait_stream(ga)
+            default.wait_stream(gb)
+
+        record(f"green_a{granted[0]}_b{granted[1]}", green, ref_topk)
+
+    for a_sms in args.a_slices:
+        b_sms = total_sms - a_sms
+        (ga, gb), res = split_device_green_ctx_by_sm_count(0, [a_sms, b_sms])
+        granted = [r.sm.smCount for r in res]
+
+        def green_narrow():
+            ga.wait_stream(default)
+            gb.wait_stream(default)
+            with torch.cuda.stream(ga):
+                wl.side_a()
+            with torch.cuda.stream(gb):
+                out = wl.side_b_proj()
+            default.wait_stream(gb)
+            wl.side_b_logits_topk(*out)
+            default.wait_stream(ga)
+
+        record(f"green_narrow_a{granted[0]}", green_narrow, ref_topk)
+
+    serial_ms = results["serial"]["median_ms"]
+    print(
+        f"\nM={args.m} N={args.n} sub_chunk={wl.sub_chunk_rows} total_sms={total_sms}"
+    )
+    for k, v in results.items():
+        if k in ("side_a_only", "side_b_only"):
+            continue
+        print(
+            f"{k:>28}: {v['median_ms']:8.3f} ms  speedup vs serial: {serial_ms / v['median_ms']:6.3f}x"
+        )
+
+    if args.json_out:
+        meta = dict(m=args.m, n=args.n, sub_chunk=wl.sub_chunk_rows, results=results)
+        with open(args.json_out, "w") as f:
+            json.dump(meta, f, indent=1)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-tasks/m4-step1-bench/trace_coresidency.py
+++ b/agent-tasks/m4-step1-bench/trace_coresidency.py
@@ -1,0 +1,72 @@
+"""Prove the green-ctx arm really co-resides: trace one green_a16_b132 region
+and report how much of side A's kernel time overlaps side B's kernel time."""
+
+import json
+import sys
+
+import torch
+
+sys.path.insert(0, "scratch/m4_green_ctx_overlap")
+from bench_step1 import Workload
+
+from sglang.srt.multiplex.green_ctx import split_device_green_ctx_by_sm_count
+
+torch.cuda.set_device(0)
+wl = Workload(16384, 81920, 0)
+default = torch.cuda.current_stream()
+(ga, gb), res = split_device_green_ctx_by_sm_count(0, [16, 132])
+print("granted:", [r.sm.smCount for r in res])
+
+
+def green():
+    ga.wait_stream(default)
+    gb.wait_stream(default)
+    with torch.cuda.stream(ga):
+        wl.side_a()
+    with torch.cuda.stream(gb):
+        wl.side_b()
+    default.wait_stream(ga)
+    default.wait_stream(gb)
+
+
+for _ in range(3):
+    green()
+torch.cuda.synchronize()
+
+with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CUDA]) as prof:
+    green()
+    torch.cuda.synchronize()
+
+trace_path = "scratch/m4_green_ctx_overlap/green_a16.trace.json"
+prof.export_chrome_trace(trace_path)
+
+events = json.load(open(trace_path))["traceEvents"]
+kernels = [e for e in events if e.get("cat") == "kernel"]
+streams = {}
+for e in kernels:
+    streams.setdefault(e["args"]["stream"], []).append((e["ts"], e["ts"] + e["dur"]))
+print(
+    {
+        s: (len(v), f"{sum(b - a for a, b in v) / 1e3:.3f} ms")
+        for s, v in streams.items()
+    }
+)
+
+sids = sorted(streams, key=lambda s: sum(b - a for a, b in streams[s]))
+a_sid, b_sid = sids[-2], sids[-1]  # side A: smaller busy time; side B: larger
+
+
+def overlap(iv_a, iv_b):
+    tot = 0.0
+    for a0, a1 in iv_a:
+        for b0, b1 in iv_b:
+            tot += max(0.0, min(a1, b1) - max(a0, b0))
+    return tot
+
+
+a_busy = sum(b - a for a, b in streams[a_sid])
+ov = overlap(streams[a_sid], streams[b_sid])
+print(
+    f"side A stream {a_sid}: busy {a_busy/1e3:.3f} ms; "
+    f"overlapped with side B stream {b_sid}: {ov/1e3:.3f} ms ({100*ov/a_busy:.1f}%)"
+)


### PR DESCRIPTION
## What + why (one line)

Step-1 settling experiment for `agent-tasks/M4-green-context-indexer-attn-overlap.md`: green-context SM partitioning of the DSA indexer against the main-attention Q projection at long prefill **does not beat serial anywhere** — per the task's own gate, the task stops here with a documented no-go (no integration, Steps 2–5 moot).

## Step-1 go/no-go table (GLM-5.2 TP4 per-rank shapes, B300, production kernels; speedup vs serial)

| arm | M=16k,N=16k | M=16k,N=49k | M=16k,N=82k | M=32k,N=32k | M=82k,N=82k |
|---|---|---|---|---|---|
| serial (today) | 1.000× | 1.000× | 1.000× | 1.000× | 1.000× |
| two-stream, one SM pool | 0.994× | 1.011× | 0.996× | 0.997× | 0.993× |
| **green-ctx, best split (a8/b140)** | — | — | **0.975×** | — | **0.980×** |
| green-ctx a16/b132 | 0.83× | 0.72× | 0.934× | 0.77× | 0.959× |
| green narrow (proj-only), best | 0.989× | 0.980× | 0.953× | 0.972× | 0.998× |

DeepSeek-V3.2 TP8 shapes: best green arm 0.976×. `workqueue_scope=balanced` (CUDA 13.1): 0.990×. Green-ctx creation: 0.4 ms one-time (not the bottleneck). Full table, methodology, and raw JSON in `agent-tasks/M4-green-context-indexer-attn-overlap-RESULT.md` + `agent-tasks/m4-step1-bench/`.

## Why no SM split can win (the arithmetic)

- The only main-side work independent of the indexer output (q_b_proj + split + absorbed bmm) is **1.2–4.7% of the overlap region**; the brief's "~16%" is the indexer's *own* logits+topk e2e share — it sits on the indexer side of the overlap and is not recoverable by this overlap.
- Both sides are throughput-bound at long-prefill sizes (near-linear SM scaling, verified by trace), and the **minimum SM carve-out on B300 is 8/148 = 5.4% > the 1.2–4.7% prize**, so the partition tax exceeds the hidden work at every ratio, wide or narrow.
- Co-residency itself was verified real: profiler trace shows **94.8%** of side-A kernel time overlapping side B on disjoint slices. The mechanism works; the economics don't.
- Free-overlap e2e ceiling ≈ **<1%** of an 80k prefill (0.23 ms × 5 chunks × 22 full-indexer layers, GLM-5.2 `index_topk_freq=4`); measured green delta is negative.

## Hazard worth keeping (for any future green-ctx work)

`deep_gemm.fp8_mqa_logits` sizes its persistent grid from `deep_gemm.get_num_sms()` (148). On a 140-SM slice the 148-CTA grid runs as **two waves → ~2× logits slowdown** (0.71× overall) unless per-slice SM counts are re-plumbed into deep_gemm. Reproducible via `--deepgemm-slice-sms` in the bench.

## Notes

- The indexer's internal `wq_b ∥ wk_weights_proj` two-stream overlap (`_fused_q_prepare_and_store`) already runs at eager prefill today, so the "projections" the task targeted were already partially overlapped. The decode two-stream path and #27705's indexer-internal dual-stream are untouched (no product code changed at all).
- Bit-identical check: top-k selected *sets* identical across all arms; the fused top-k kernel returns the set in nondeterministic order run-to-run (pre-existing, input-independent of this experiment).

Refs: sgl-project/sglang#27705.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vincentzed/sglang/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

