### PR TITLE
Fix H20 DSA DCP with FlashMLA KV

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -515,14 +515,6 @@ class DeepseekSparseAttnBackend(
                 "extend rows, and prefill CP splits rows across ranks."
             )
             assert self.hisparse_coordinator is None, "DCP does not support hisparse."
-            if self.use_fused_topk:
-                # Fused top-k v2 under DCP is measured incorrect on the
-                # current tree (gsm8k 0.000 vs 0.920 with fusion off, single
-                # commit delta); disable until the v2 transform composes with
-                # the owner filter again. Costs decode perf, tracked in the
-                # PR's F-list.
-                print_warning_once("Disabling fused DSA top-k under DCP.")
-                self.use_fused_topk = False
             if model_runner.server_args.enable_dp_attention:
                 # Keep each DCP group inside one attention-DP shard so the
                 # replicated indexer sees identical requests group-wide.
@@ -813,6 +805,23 @@ class DeepseekSparseAttnBackend(
             return topk_indices
         raise RuntimeError(
             f"Unsupported {self.dsa_topk_backend = } for SGLANG_DSA_FUSE_TOPK."
+        )
+
+    def _use_fused_topk_for_batch(self, forward_batch: ForwardBatch) -> bool:
+        """Whether the indexer returned physical slots for this batch.
+
+        Keep this producer/consumer decision centralized. In particular, DCP
+        extend batches intentionally run the unfused top-k path, which returns
+        sequence-relative positions that attention must still map through the
+        page table. Treating those positions as fused physical slots corrupts
+        prefill attention even when fused decode itself is correct.
+        """
+        return self.use_fused_topk and not (
+            (
+                self.hisparse_coordinator is not None
+                and forward_batch.forward_mode.is_decode_or_idle()
+            )
+            or (self.dcp_enabled and not forward_batch.forward_mode.is_decode_or_idle())
         )
 
     def _dcp_global_slots_to_local_rows(
@@ -2053,7 +2062,7 @@ class DeepseekSparseAttnBackend(
             forward_batch.forward_mode
         )
 
-        if self.use_fused_topk and not self.dcp_enabled:
+        if self._use_fused_topk_for_batch(forward_batch):
             # Under DCP, extend stays on the unfused transform (see
             # get_indexer_metadata): the fused v2 transform is decode-shaped
             # and ~2x slower on large extend chunks.
@@ -2320,7 +2329,7 @@ class DeepseekSparseAttnBackend(
                 topk_indices,
                 layer.layer_id,
             )
-        elif self.use_fused_topk:
+        elif self._use_fused_topk_for_batch(forward_batch):
             page_table_1 = self._get_fused_topk_page_table(topk_indices)
         else:
             page_table_1 = transform_index_page_table_decode(
@@ -3027,7 +3036,7 @@ class DeepseekSparseAttnBackend(
         else:
             q_all = q.view(-1, layer.tp_q_head_num, layer.head_dim)
 
-        if self.use_fused_topk:
+        if self._use_fused_topk_for_batch(forward_batch):
             if topk_indices is not None:
                 topk_indices = self._pad_topk_indices(topk_indices, q.shape[0])
             page_table_1 = self._get_fused_topk_page_table(topk_indices)
@@ -3267,18 +3276,10 @@ class DeepseekSparseAttnBackend(
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> DSAIndexerMetadata:
-        force_unfused = (
-            not self.use_fused_topk
-            or (
-                self.hisparse_coordinator is not None
-                and forward_batch.forward_mode.is_decode_or_idle()
-            )
-            # Under DCP, fuse decode only: the v2 fused transform is
-            # decode/MTP-shaped and measured ~2x slower on 32k-row extend
-            # chunks; extend uses the unfused transform (positions), which
-            # carries the DCP owner filter itself.
-            or (self.dcp_enabled and not forward_batch.forward_mode.is_decode_or_idle())
-        )
+        # Under DCP, fuse decode only: the v2 fused transform is
+        # decode/MTP-shaped and measured ~2x slower on 32k-row extend chunks.
+        # The same decision is used by attention when interpreting the result.
+        force_unfused = not self._use_fused_topk_for_batch(forward_batch)
         return DSAIndexerMetadata(
             attn_metadata=self.forward_metadata,
             topk_transform_method=self.get_topk_transform_method(

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -85,6 +85,11 @@ from sglang.srt.utils import (
 # concat). Enable with SGLANG_DSA_TRITON_PREFILL=1. Decode stays on TileLang.
 _DSA_TRITON_PREFILL = get_bool_env_var("SGLANG_DSA_TRITON_PREFILL")
 _IS_GFX95 = is_gfx95_supported()
+
+# cp_lse_ag_out_rs_mla uses exp2/log2. FlashMLA KV decode exposes natural-log
+# LSE, so normalize it at the DSA backend boundary before the DCP combine.
+_LOG2_E = 1.4426950408889634
+
 if is_cuda():
     import deep_gemm
 
@@ -466,13 +471,44 @@ class DeepseekSparseAttnBackend(
         self.dcp_size = parallel.attn_dcp_size if self.dcp_enabled else 1
         self.dcp_rank = parallel.attn_dcp_rank if self.dcp_enabled else 0
         if self.dcp_enabled:
-            assert (
-                self.dsa_decode_impl == "trtllm" and self.dsa_prefill_impl == "trtllm"
-            ), (
-                "DCP requires the trtllm DSA backends (the sm100 defaults); "
-                f"got decode={self.dsa_decode_impl}, "
-                f"prefill={self.dsa_prefill_impl}."
-            )
+            dsa_backend_pair = (self.dsa_prefill_impl, self.dsa_decode_impl)
+            if dsa_backend_pair == ("trtllm", "trtllm"):
+                pass
+            elif dsa_backend_pair == ("flashmla_kv", "flashmla_kv"):
+                if self.device_sm_major != 9:
+                    raise ValueError(
+                        "DSA DCP with flashmla_kv is currently enabled only on "
+                        f"SM90 (Hopper/H20); got compute capability "
+                        f"sm_{self.device_capability[0]}{self.device_capability[1]}. "
+                        "Use the trtllm/trtllm DSA backend pair on SM100+."
+                    )
+                if not self.dsa_kv_cache_store_fp8:
+                    raise ValueError(
+                        "DSA DCP with flashmla_kv requires an FP8 KV cache; launch "
+                        "with --kv-cache-dtype fp8_e4m3. The BF16 FlashMLA sparse "
+                        "path has a different kernel/LSE contract and is not enabled "
+                        "by this implementation."
+                    )
+                # The model-side DCP Q all-gather widens the local TP head
+                # group. FlashMLA metadata and padding must target that widened
+                # count, not the pre-gather self.num_q_heads value.
+                dcp_num_q_heads = self.num_q_heads * self.dcp_size
+                if dcp_num_q_heads <= 64:
+                    self.flashmla_kv_num_q_heads = 64
+                elif dcp_num_q_heads <= 128:
+                    self.flashmla_kv_num_q_heads = 128
+                else:
+                    self.flashmla_kv_num_q_heads = dcp_num_q_heads
+            else:
+                raise ValueError(
+                    "Unsupported DSA backend pair for DCP: "
+                    f"prefill={self.dsa_prefill_impl}, "
+                    f"decode={self.dsa_decode_impl}. Supported pairs are "
+                    "trtllm/trtllm (SM100+) and flashmla_kv/flashmla_kv "
+                    "(SM90 with --kv-cache-dtype fp8_e4m3). Mixed pairs are "
+                    "rejected until their LSE and zero-local-KV contracts are "
+                    "validated together."
+                )
             assert not model_runner.server_args.enable_prefill_cp, (
                 "DCP does not compose with prefill CP yet: the DCP extend "
                 "recipe assumes every rank in a DCP group holds the same "
@@ -2171,6 +2207,7 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 page_table_1=page_table_1,
+                return_lse=self.dcp_enabled,
             )
         elif dsa_impl == "fa3":
             return self._forward_fa3(
@@ -2316,6 +2353,7 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 page_table_1=page_table_1,
+                return_lse=self.dcp_enabled,
             )
         elif self.dsa_decode_impl == "tilelang":
             # Cat-skip (HIP-only): when caller passes q_rope=None on HIP, q_all
@@ -2582,7 +2620,8 @@ class DeepseekSparseAttnBackend(
         layer,
         metadata: DSAMetadata,
         page_table_1,
-    ) -> torch.Tensor:
+        return_lse: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         from sgl_kernel.flash_mla import flash_mla_with_kvcache
 
         cache_seqlens = metadata.dsa_cache_seqlens_int32
@@ -2613,7 +2652,7 @@ class DeepseekSparseAttnBackend(
             indices.shape[-1] == self.dsa_index_topk
         )  # requirement of FlashMLA decode kernel
 
-        o, _ = flash_mla_with_kvcache(
+        o, lse = flash_mla_with_kvcache(
             q=q_input,
             k_cache=kv_cache,
             cache_seqlens=cache_seqlens,
@@ -2631,6 +2670,28 @@ class DeepseekSparseAttnBackend(
 
         if target_q_heads != num_q_heads:
             o = o[:, :, :num_q_heads, :]
+            lse = lse[:, :num_q_heads, :]
+
+        if return_lse:
+            # FlashMLA KV returns natural-log LSE [B, H, 1], whereas the MLA
+            # DCP correction kernel consumes base-2 LSE [B, H]. Normalize here
+            # so the model-level combine has one backend-independent contract.
+            o = o.squeeze(1)
+            lse = lse.squeeze(-1).to(torch.float32).mul_(_LOG2_E).contiguous()
+
+            # The DCP owner filter leaves -1 holes. A short request can leave a
+            # rank with no selected KV at all; force that partial to the online
+            # softmax identity (out=0, LSE=-inf) before the cross-rank combine.
+            dcp_local_counts = (page_table_1 >= 0).sum(dim=-1, dtype=torch.int32)
+            batch_size = page_table_1.shape[0]
+            fixup_zero_kv_rows(
+                o,
+                lse,
+                dcp_local_counts,
+                self.get_device_int32_arange(batch_size + 1),
+                max_seq_len=1,
+            )
+            return o, lse
 
         return o
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -2676,7 +2676,10 @@ class DeepseekSparseAttnBackend(
             # FlashMLA KV returns natural-log LSE [B, H, 1], whereas the MLA
             # DCP correction kernel consumes base-2 LSE [B, H]. Normalize here
             # so the model-level combine has one backend-independent contract.
-            o = o.squeeze(1)
+            # Head padding makes the trimmed view non-contiguous for DCP2/4.
+            # The zero-KV fixup kernel and the model-level DCP combine both use
+            # packed [B, H, D] row strides, so materialize that layout here.
+            o = o.squeeze(1).contiguous()
             lse = lse.squeeze(-1).to(torch.float32).mul_(_LOG2_E).contiguous()
 
             # The DCP owner filter leaves -1 holes. A short request can leave a

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -73,6 +73,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _get_dsa_indexer_cache_token_multiplier(kvc: KVCacheConfigurator) -> int:
+    """Return indexer-cache slots allocated per allocator-visible token."""
+    if kvc.server_args.enable_hisparse:
+        from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+
+        return parse_hisparse_config(kvc.server_args).host_to_device_ratio
+
+    parallel = get_parallel()
+    return parallel.attn_dcp_size if parallel.dcp_enabled else 1
+
+
 def _get_dsv4_compress_state_dtype_sizes() -> tuple[int, int]:
     dtype_name = envs.SGLANG_DSV4_COMPRESS_STATE_DTYPE.get().strip().lower()
     if dtype_name in ("float32", "fp32"):
@@ -213,7 +224,10 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                     DSATokenToKVPool.index_k_with_scale_buffer_dtype
                 )
                 cell_size += (
-                    indexer_size_per_token * effective_num_layers * element_size
+                    indexer_size_per_token
+                    * effective_num_layers
+                    * element_size
+                    * _get_dsa_indexer_cache_token_multiplier(kvc)
                 )
         elif is_minimax_sparse(model_config.hf_config):
             # Mirrors MiniMaxSparseKVPool: main pool (K+V all layers) + indexer pool

--- a/test/manual/layers/attention/dsa/test_flashmla_kv_dcp_sm90.py
+++ b/test/manual/layers/attention/dsa/test_flashmla_kv_dcp_sm90.py
@@ -1,0 +1,164 @@
+"""Four-GPU FlashMLA-KV DCP correctness check for SM90.
+
+Run with:
+    torchrun --master-addr 127.0.0.1 --master-port 29591 --nproc-per-node 4 \
+      test/manual/layers/attention/dsa/test_flashmla_kv_dcp_sm90.py
+
+This intentionally avoids model weights. It exercises the production DCP owner
+rule, FP8 KV layout, FlashMLA's -1 sparse-index holes, natural-log LSE
+normalization, and the cross-rank online-softmax merge.
+"""
+
+import os
+
+import torch
+import torch.distributed as dist
+
+from sgl_kernel.flash_mla import flash_mla_with_kvcache, get_mla_metadata
+from sglang.kernels.ops.attention.dsa.quant_k_cache import quantize_k_cache
+
+
+LOG2_E = 1.4426950408889634
+SEQ_LEN = 4096
+TOPK = 2048
+NUM_HEADS = 64
+HEAD_DIM = 576
+VALUE_DIM = 512
+PAGE_SIZE = 64
+
+
+def _flashmla_sparse_decode(
+    q: torch.Tensor,
+    kv_bf16: torch.Tensor,
+    indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens = kv_bf16.shape[0]
+    padded_tokens = ((num_tokens + PAGE_SIZE - 1) // PAGE_SIZE) * PAGE_SIZE
+    kv_padded = torch.zeros(
+        padded_tokens, HEAD_DIM, dtype=torch.bfloat16, device=q.device
+    )
+    kv_padded[:num_tokens] = kv_bf16
+    kv_fp8 = quantize_k_cache(kv_padded.view(-1, PAGE_SIZE, 1, HEAD_DIM))
+
+    cache_seqlens = torch.tensor([TOPK], dtype=torch.int32, device=q.device)
+    scheduler_metadata, num_splits = get_mla_metadata(
+        cache_seqlens=cache_seqlens,
+        num_q_tokens_per_head_k=NUM_HEADS,
+        num_heads_k=1,
+        num_heads_q=NUM_HEADS,
+        is_fp8_kvcache=True,
+        topk=TOPK,
+    )
+    out, natural_lse = flash_mla_with_kvcache(
+        q=q.view(1, 1, NUM_HEADS, HEAD_DIM),
+        k_cache=kv_fp8,
+        block_table=torch.empty((1, 0), dtype=torch.int32, device=q.device),
+        cache_seqlens=cache_seqlens,
+        head_dim_v=VALUE_DIM,
+        tile_scheduler_metadata=scheduler_metadata,
+        num_splits=num_splits,
+        softmax_scale=HEAD_DIM**-0.5,
+        is_fp8_kvcache=True,
+        indices=indices.view(1, 1, TOPK),
+    )
+    return out.view(NUM_HEADS, VALUE_DIM), natural_lse.view(NUM_HEADS)
+
+
+@torch.inference_mode()
+def main() -> None:
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    if world_size != 4:
+        raise ValueError(f"This test requires four ranks, got {world_size}.")
+
+    device = torch.device("cuda", local_rank)
+    if torch.cuda.get_device_capability(device)[0] != 9:
+        raise ValueError("flashmla_kv DCP integration test requires SM90.")
+
+    if rank == 0:
+        generator = torch.Generator(device=device).manual_seed(20260731)
+        q = torch.randn(
+            NUM_HEADS,
+            HEAD_DIM,
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        ).clamp_(-1, 1)
+        global_kv = (
+            torch.randn(
+                SEQ_LEN,
+                HEAD_DIM,
+                dtype=torch.bfloat16,
+                device=device,
+                generator=generator,
+            )
+            / 10
+        ).clamp_(-1, 1)
+        topk_indices = torch.randperm(
+            SEQ_LEN, dtype=torch.int32, device=device, generator=generator
+        )[:TOPK]
+    else:
+        q = torch.empty(NUM_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+        global_kv = torch.empty(SEQ_LEN, HEAD_DIM, dtype=torch.bfloat16, device=device)
+        topk_indices = torch.empty(TOPK, dtype=torch.int32, device=device)
+
+    dist.broadcast(q, src=0)
+    dist.broadcast(global_kv, src=0)
+    dist.broadcast(topk_indices, src=0)
+
+    # Production owner rule: global slot g belongs to rank g % DCP, at local
+    # row g // DCP. Unowned TopK entries remain -1 holes for FlashMLA.
+    local_kv = global_kv[rank::world_size].contiguous()
+    owned = topk_indices.remainder(world_size) == rank
+    local_indices = torch.where(
+        owned, topk_indices // world_size, torch.full_like(topk_indices, -1)
+    )
+    local_out, local_natural_lse = _flashmla_sparse_decode(q, local_kv, local_indices)
+
+    # Match the SGLang patch: normalize FlashMLA's natural-log LSE to base-2,
+    # then perform the same online-softmax correction across DCP ranks.
+    local_lse = local_natural_lse.float() * LOG2_E
+    gathered_lse = [torch.empty_like(local_lse) for _ in range(world_size)]
+    dist.all_gather(gathered_lse, local_lse)
+    lse_stack = torch.stack(gathered_lse)
+    ln_2 = torch.log(torch.tensor(2.0, device=device))
+    global_lse = torch.logsumexp(lse_stack * ln_2, dim=0) * LOG2_E
+    local_weight = torch.exp2(local_lse - global_lse).unsqueeze(-1)
+    merged_out = local_out.float() * local_weight
+    dist.all_reduce(merged_out)
+
+    if rank == 0:
+        reference_out, reference_natural_lse = _flashmla_sparse_decode(
+            q, global_kv, topk_indices
+        )
+        torch.testing.assert_close(
+            merged_out,
+            reference_out.float(),
+            atol=2e-2,
+            rtol=2e-2,
+        )
+        torch.testing.assert_close(
+            global_lse,
+            reference_natural_lse.float() * LOG2_E,
+            atol=2e-3,
+            rtol=2e-3,
+        )
+        max_out_error = (merged_out - reference_out.float()).abs().max().item()
+        max_lse_error = (
+            (global_lse - reference_natural_lse.float() * LOG2_E).abs().max().item()
+        )
+        print(
+            "FlashMLA KV DCP SM90 passed: "
+            f"max_out_error={max_out_error:.6f}, "
+            f"max_lse_error={max_lse_error:.6f}"
+        )
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/layers/attention/dsa/test_fused_topk_dcp_sm90.py
+++ b/test/manual/layers/attention/dsa/test_fused_topk_dcp_sm90.py
@@ -1,0 +1,113 @@
+"""Compare fused-v2 and unfused DSA top-k slot transforms under DCP.
+
+Run on one SM90 GPU; DCP ranks are emulated after the common global-slot
+transform because the indexer and its page table are replicated group-wide.
+
+    CUDA_VISIBLE_DEVICES=0 python3 test/manual/layers/attention/dsa/test_fused_topk_dcp_sm90.py
+"""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.topk import (
+    plan_topk_v2,
+    topk_transform_512_v2,
+)
+
+
+PAGE_SIZE = 64
+TOPK = 2048
+
+
+def _make_dcp_page_tables(
+    batch_size: int, seq_len: int, dcp_size: int, device: str
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build the layout produced by allocator pages of PAGE_SIZE * dcp_size."""
+    superpage_size = PAGE_SIZE * dcp_size
+    num_superpages = (seq_len + superpage_size - 1) // superpage_size
+    rows = []
+    for batch_id in range(batch_size):
+        generator = torch.Generator(device=device).manual_seed(
+            1009 * dcp_size + batch_id
+        )
+        # Give each request a disjoint, permuted global-slot region.
+        superpages = torch.randperm(
+            num_superpages, generator=generator, device=device
+        ) + batch_id * num_superpages
+        offsets = torch.arange(superpage_size, device=device)
+        slots = (superpages[:, None] * superpage_size + offsets[None, :]).flatten()
+        rows.append(slots[:seq_len])
+
+    page_table_1 = torch.stack(rows).to(torch.int32)
+    real_page_table = page_table_1[:, ::PAGE_SIZE] // PAGE_SIZE
+    return page_table_1, real_page_table
+
+
+@torch.inference_mode()
+def main() -> None:
+    assert torch.cuda.get_device_capability()[0] == 9
+    device = "cuda"
+    torch.manual_seed(20260731)
+
+    for dcp_size in (2, 4, 8):
+        for batch_size, seq_len in ((4, 4096), (4, 16385), (2, 65537)):
+            width = (seq_len + 3) & ~3
+            scores = torch.randn(
+                batch_size, width, dtype=torch.float32, device=device
+            )[:, :seq_len]
+            seq_lens = torch.full(
+                (batch_size,), seq_len, dtype=torch.int32, device=device
+            )
+            page_table_1, real_page_table = _make_dcp_page_tables(
+                batch_size, seq_len, dcp_size, device
+            )
+
+            raw = torch.topk(scores, TOPK, dim=-1, sorted=False).indices
+            unfused_global = torch.gather(page_table_1, 1, raw).to(torch.int32)
+
+            fused_global = torch.full(
+                (batch_size, TOPK), -1, dtype=torch.int32, device=device
+            )
+            plan = plan_topk_v2(seq_lens)
+            topk_transform_512_v2(
+                scores,
+                seq_lens,
+                real_page_table,
+                fused_global,
+                PAGE_SIZE,
+                plan,
+            )
+            torch.cuda.synchronize()
+
+            for dcp_rank in range(dcp_size):
+                fused_local = torch.where(
+                    fused_global % dcp_size == dcp_rank,
+                    fused_global // dcp_size,
+                    -1,
+                )
+                unfused_local = torch.where(
+                    unfused_global % dcp_size == dcp_rank,
+                    unfused_global // dcp_size,
+                    -1,
+                )
+
+                # Order is irrelevant to sparse attention. Random fp32 scores
+                # make boundary ties negligibly likely, so compare slot sets.
+                for row in range(batch_size):
+                    fused_set = set(fused_local[row][fused_local[row] >= 0].tolist())
+                    unfused_set = set(
+                        unfused_local[row][unfused_local[row] >= 0].tolist()
+                    )
+                    assert fused_set == unfused_set, (
+                        f"mismatch: {dcp_size=} {dcp_rank=} {batch_size=} "
+                        f"{seq_len=} row={row} "
+                        f"only_fused={list(fused_set - unfused_set)[:8]} "
+                        f"only_unfused={list(unfused_set - fused_set)[:8]}"
+                    )
+
+            print(f"passed: dcp={dcp_size} batch={batch_size} seq={seq_len}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/dcp/test_dsa_flashmla_kv_dcp.py
+++ b/test/registered/dcp/test_dsa_flashmla_kv_dcp.py
@@ -17,9 +17,7 @@ register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-small")
 class TestDSAFlashMLAKVDCP(unittest.TestCase):
     @patch("sglang.srt.layers.attention.dsa_backend.fixup_zero_kv_rows")
     @patch("sgl_kernel.flash_mla.flash_mla_with_kvcache")
-    def test_returns_base2_lse_and_zero_row_metadata(
-        self, mock_flashmla, mock_fixup
-    ):
+    def test_returns_base2_lse_and_zero_row_metadata(self, mock_flashmla, mock_fixup):
         backend = object.__new__(DeepseekSparseAttnBackend)
         backend.real_page_size = 64
         backend.kv_cache_dim = 4
@@ -35,9 +33,7 @@ class TestDSAFlashMLAKVDCP(unittest.TestCase):
         value_dim = 3
         q = torch.zeros(batch_size, actual_heads, 4, dtype=torch.bfloat16)
         kv = torch.zeros(2 * 64 * 4, dtype=torch.bfloat16)
-        page_table = torch.tensor(
-            [[0, 1, -1, -1], [-1, -1, -1, -1]], dtype=torch.int32
-        )
+        page_table = torch.tensor([[0, 1, -1, -1], [-1, -1, -1, -1]], dtype=torch.int32)
         metadata = SimpleNamespace(
             dsa_cache_seqlens_int32=torch.tensor([2, 0], dtype=torch.int32),
             flashmla_metadata=DSAFlashMLAMetadata(

--- a/test/registered/dcp/test_dsa_flashmla_kv_dcp.py
+++ b/test/registered/dcp/test_dsa_flashmla_kv_dcp.py
@@ -1,0 +1,93 @@
+import math
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.attention.dsa_backend import (
+    DSAFlashMLAMetadata,
+    DeepseekSparseAttnBackend,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestDSAFlashMLAKVDCP(unittest.TestCase):
+    @patch("sglang.srt.layers.attention.dsa_backend.fixup_zero_kv_rows")
+    @patch("sgl_kernel.flash_mla.flash_mla_with_kvcache")
+    def test_returns_base2_lse_and_zero_row_metadata(
+        self, mock_flashmla, mock_fixup
+    ):
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        backend.real_page_size = 64
+        backend.kv_cache_dim = 4
+        backend.dsa_kv_cache_store_fp8 = True
+        backend.dsa_index_topk = 4
+        backend.flashmla_kv_num_q_heads = 4
+        backend.get_device_int32_arange = lambda length: torch.arange(
+            length, dtype=torch.int32
+        )
+
+        batch_size = 2
+        actual_heads = 2
+        value_dim = 3
+        q = torch.zeros(batch_size, actual_heads, 4, dtype=torch.bfloat16)
+        kv = torch.zeros(2 * 64 * 4, dtype=torch.bfloat16)
+        page_table = torch.tensor(
+            [[0, 1, -1, -1], [-1, -1, -1, -1]], dtype=torch.int32
+        )
+        metadata = SimpleNamespace(
+            dsa_cache_seqlens_int32=torch.tensor([2, 0], dtype=torch.int32),
+            flashmla_metadata=DSAFlashMLAMetadata(
+                flashmla_metadata=torch.empty(0, dtype=torch.int32),
+                num_splits=torch.empty(0, dtype=torch.int32),
+            ),
+        )
+        layer = SimpleNamespace(tp_q_head_num=actual_heads, head_dim=4)
+
+        mock_flashmla.return_value = (
+            torch.ones(batch_size, 1, 4, value_dim, dtype=torch.bfloat16),
+            torch.log(
+                torch.tensor(
+                    [
+                        [[2.0], [8.0], [4.0], [16.0]],
+                        [[4.0], [16.0], [2.0], [8.0]],
+                    ]
+                )
+            ),
+        )
+
+        out, lse = backend._forward_flashmla_kv(
+            q_all=q,
+            kv_cache=kv,
+            v_head_dim=value_dim,
+            sm_scale=1.0,
+            layer=layer,
+            metadata=metadata,
+            page_table_1=page_table,
+            return_lse=True,
+        )
+
+        self.assertEqual(out.shape, (batch_size, actual_heads, value_dim))
+        torch.testing.assert_close(
+            lse,
+            torch.tensor([[1.0, 3.0], [2.0, 4.0]]),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+        self.assertAlmostEqual(lse[0, 0].item(), math.log2(2.0))
+
+        mock_fixup.assert_called_once()
+        fixup_args = mock_fixup.call_args.args
+        torch.testing.assert_close(
+            fixup_args[2], torch.tensor([2, 0], dtype=torch.int32)
+        )
+        torch.testing.assert_close(
+            fixup_args[3], torch.tensor([0, 1, 2], dtype=torch.int32)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/dcp/test_dsa_flashmla_kv_dcp.py
+++ b/test/registered/dcp/test_dsa_flashmla_kv_dcp.py
@@ -67,6 +67,7 @@ class TestDSAFlashMLAKVDCP(unittest.TestCase):
         )
 
         self.assertEqual(out.shape, (batch_size, actual_heads, value_dim))
+        self.assertTrue(out.is_contiguous())
         torch.testing.assert_close(
             lse,
             torch.tensor([[1.0, 3.0], [2.0, 4.0]]),

--- a/test/registered/dcp/test_dsa_fused_topk_modes.py
+++ b/test/registered/dcp/test_dsa_fused_topk_modes.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+import pytest
+
+from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+
+@pytest.mark.parametrize(
+    "mode, expected",
+    [
+        (ForwardMode.DECODE, True),
+        (ForwardMode.IDLE, True),
+        (ForwardMode.EXTEND, False),
+        (ForwardMode.MIXED, False),
+        (ForwardMode.TARGET_VERIFY, False),
+        (ForwardMode.DRAFT_EXTEND_V2, False),
+    ],
+)
+def test_dcp_fuses_decode_only(mode: ForwardMode, expected: bool) -> None:
+    backend = DeepseekSparseAttnBackend.__new__(DeepseekSparseAttnBackend)
+    backend.use_fused_topk = True
+    backend.dcp_enabled = True
+    backend.hisparse_coordinator = None
+
+    forward_batch = SimpleNamespace(forward_mode=mode)
+    assert backend._use_fused_topk_for_batch(forward_batch) is expected
+
+
+def test_fused_topk_disabled_is_shared_by_producer_and_consumer() -> None:
+    backend = DeepseekSparseAttnBackend.__new__(DeepseekSparseAttnBackend)
+    backend.use_fused_topk = False
+    backend.dcp_enabled = True
+    backend.hisparse_coordinator = None
+    forward_batch = SimpleNamespace(forward_mode=ForwardMode.DECODE)
+
+    assert not backend._use_fused_topk_for_batch(forward_batch)
+
+
+def test_non_dcp_extend_keeps_existing_fused_behavior() -> None:
+    backend = DeepseekSparseAttnBackend.__new__(DeepseekSparseAttnBackend)
+    backend.use_fused_topk = True
+    backend.dcp_enabled = False
+    backend.hisparse_coordinator = None
+    forward_batch = SimpleNamespace(forward_mode=ForwardMode.EXTEND)
+
+    assert backend._use_fused_topk_for_batch(forward_batch)

--- a/test/registered/dcp/test_dsa_pool_sizing.py
+++ b/test/registered/dcp/test_dsa_pool_sizing.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.model_executor.pool_configurator import (
+    DefaultPoolConfigurator,
+    _get_dsa_indexer_cache_token_multiplier,
+)
+from sglang.srt.runtime_context import get_parallel
+
+
+def _kvc(*, enable_hisparse: bool = False):
+    return SimpleNamespace(
+        server_args=SimpleNamespace(enable_hisparse=enable_hisparse)
+    )
+
+
+def test_dsa_indexer_cache_is_replicated_across_dcp_ranks() -> None:
+    with get_parallel().override(dcp_enabled=True, attn_dcp_size=8):
+        assert _get_dsa_indexer_cache_token_multiplier(_kvc()) == 8
+
+
+def test_dsa_indexer_cache_has_no_multiplier_without_dcp() -> None:
+    with get_parallel().override(dcp_enabled=False, attn_dcp_size=1):
+        assert _get_dsa_indexer_cache_token_multiplier(_kvc()) == 1
+
+
+def test_dsa_cell_size_accounts_for_dcp_indexer_replication() -> None:
+    kvc = SimpleNamespace(
+        use_mla_backend=True,
+        kv_cache_dtype=torch.float8_e4m3fn,
+        model_config=SimpleNamespace(
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            hf_config=SimpleNamespace(),
+        ),
+        server_args=SimpleNamespace(enable_hisparse=False),
+    )
+    configurator = object.__new__(DefaultPoolConfigurator)
+
+    with (
+        get_parallel().override(
+            attn_tp_size=8, dcp_enabled=True, attn_dcp_size=8
+        ),
+        patch(
+            "sglang.srt.layers.cp.utils."
+            "get_glm_dsa_layer_split_effective_num_layers",
+            return_value=2,
+        ),
+        patch(
+            "sglang.srt.model_executor.pool_configurator.is_deepseek_dsa",
+            return_value=True,
+        ),
+    ):
+        cell_size = configurator._compute_cell_size(kvc, num_layers=2)
+
+    # Per layer: 576 bytes of MLA KV plus 132 bytes of replicated indexer KV
+    # for each of the eight DCP ranks.
+    assert cell_size == (576 + 132 * 8) * 2

--- a/test/registered/dcp/test_dsa_pool_sizing.py
+++ b/test/registered/dcp/test_dsa_pool_sizing.py
@@ -52,6 +52,10 @@ def test_dsa_cell_size_accounts_for_dcp_indexer_replication() -> None:
             "sglang.srt.model_executor.pool_configurator.is_deepseek_dsa",
             return_value=True,
         ),
+        patch(
+            "sglang.srt.model_executor.pool_configurator.get_dsa_index_head_dim",
+            return_value=128,
+        ),
     ):
         cell_size = configurator._compute_cell_size(kvc, num_layers=2)
 

--- a/test/registered/dcp/test_dsa_pool_sizing.py
+++ b/test/registered/dcp/test_dsa_pool_sizing.py
@@ -11,9 +11,7 @@ from sglang.srt.runtime_context import get_parallel
 
 
 def _kvc(*, enable_hisparse: bool = False):
-    return SimpleNamespace(
-        server_args=SimpleNamespace(enable_hisparse=enable_hisparse)
-    )
+    return SimpleNamespace(server_args=SimpleNamespace(enable_hisparse=enable_hisparse))
 
 
 def test_dsa_indexer_cache_is_replicated_across_dcp_ranks() -> None:
@@ -40,9 +38,7 @@ def test_dsa_cell_size_accounts_for_dcp_indexer_replication() -> None:
     configurator = object.__new__(DefaultPoolConfigurator)
 
     with (
-        get_parallel().override(
-            attn_tp_size=8, dcp_enabled=True, attn_dcp_size=8
-        ),
+        get_parallel().override(attn_tp_size=8, dcp_enabled=True, attn_dcp_size=8),
         patch(
             "sglang.srt.layers.cp.utils."
             "get_glm_dsa_layer_split_effective_num_layers",


### PR DESCRIPTION
# Enable H20 DSA DCP with FlashMLA KV

Stacked on [sgl-project/sglang#31821](https://github.com/sgl-project/sglang/pull/31821).

## Why

#31821 currently limits DSA DCP to the SM100 TRTLLM backend pair. On H20/SM90,
GLM-5.2 NVFP4 with FP8 KV resolves both DSA phases to `flashmla_kv`, so the
server rejects DCP even though the owner filtering and cross-rank output/LSE
combine are backend-independent.

The eight-GPU E2E run also exposed two independent correctness issues:

- the indexer produced sequence-relative positions for DCP extend while the
  TRTLLM consumer interpreted them as physical KV slots when global fused
  TopK was enabled;
- pool sizing counted replicated DSA indexer KV once, while
  `DSATokenToKVPool` allocates it for every DCP rank.

## What

- Allow the `flashmla_kv/flashmla_kv` DSA DCP pair on SM90 with FP8 KV.
- Normalize FlashMLA natural-log LSE to the base-2 DCP combine contract.
- Correct zero-local-KV rows to `out=0, LSE=-inf` and keep trimmed output
  contiguous.
- Size FlashMLA metadata for DCP-widened query heads.
- Make fused TopK a batch-level decision shared by its producer and every
  consumer: DCP decode/idle may fuse; extend-like modes remain unfused.
- Include the DCP replication factor when sizing the DSA indexer cache
  (and preserve HiSparse's explicit device ratio).

## Validation

- Relevant unit tests: `11 passed`.
- Real H20 FlashMLA FP8 kernel:
  - seq/topk 140/2048 with sparse holes: passed;
  - seq/topk 4096/2048: passed.
- Four-rank H20 DCP versus unsharded FlashMLA:
  - maximum output error: `0.000032`;
  - maximum LSE error: `0.000001`.
- Real H20 fused-v2 versus unfused TopK slots:
  - DCP 2/4/8;
  - batch 4 at seq 4096 and 16385;
  - batch 2 at seq 65537;
  - all passed.
- Full GLM-5.2-NVFP4 TP8+DCP8 E2E on eight H20 96GB GPUs:
  - FP8 KV, Marlin MoE, `flashmla_kv` prefill/decode;
  - all 12 decode CUDA Graph batch sizes through 64 captured successfully;
  - OpenAI chat request returned the correct answer `391` for `17 * 23`.
- Pool sizing regression at `--mem-fraction-static 0.8`:
  - before fix: OOM while allocating another 252 MiB index buffer with only
    118.56 MiB free;
  - after fix: server ready, 107,968 local token slots / 13.43 GiB reported KV
    per GPU, same request returned `391`.

Mixed backend pairs and BF16 `flashmla_kv` remain rejected explicitly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vincentzed/sglang/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

